### PR TITLE
Add dependencies for eist24l09p02

### DIFF
--- a/java/artemis-dos-template/build.gradle
+++ b/java/artemis-dos-template/build.gradle
@@ -23,7 +23,7 @@ sourceSets {
 }
 
 dependencies {
-    // Dependencies are copied from: https://bitbucket.ase.in.tum.de/projects/EIST24L02P02/repos/eist24l02p02-tests/browse/build.gradle
+    // Dependencies are originally copied from: https://bitbucket.ase.in.tum.de/projects/EIST24L02P02/repos/eist24l02p02-tests/browse/build.gradle
 
     // Frontend dependencies
     implementation(platform("software.amazon.awssdk:bom:2.21.1"))
@@ -38,6 +38,9 @@ dependencies {
     implementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.576'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.576'
     implementation 'com.amazonaws:aws-lambda-java-events:3.11.1'
+    implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
+    implementation 'org.apache.maven:maven-model:3.8.6'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
 
     // Test dependencies
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'


### PR DESCRIPTION

Note that these are only the dependencies (libraries) for it, the rest of the build.gradle such as the plugins on the test repository aren't shown here



[test](https://bitbucket.ase.in.tum.de/projects/EIST24L09P02/repos/eist24l09p02-tests/browse/build.gradle?until=3ecda97240f1e98a8aaab5fbb310a30303915299&untilPath=build.gradle)
[exercise](https://bitbucket.ase.in.tum.de/projects/EIST24L09P02/repos/eist24l09p02-exercise/browse/build.gradle)
[solution ](https://bitbucket.ase.in.tum.de/projects/EIST24L09P02/repos/eist24l09p02-solution/browse/build.gradle)