### PR TITLE
Update Dockerfile for dynamic analysis tasks 

### DIFF
--- a/c/Dockerfile_asan
+++ b/c/Dockerfile_asan
@@ -1,8 +1,10 @@
 # based on ubuntu:24.04
 
-# code analysis (needs specific compiler)
+# dynamic code analysis (needs specific compiler)
 # update to use gcc13 as previous versions had issues with libasan:
 # https://stackoverflow.com/questions/78136716/addresssanitizerdeadlysignal-from-fsanitize-address-flag
+# update to use latest stable clang (20.1.7) for best thread sanitizer support after the entropy update
+# https://stackoverflow.com/questions/77850769/fatal-threadsanitizer-unexpected-memory-mapping-when-running-on-linux-kernels
 
 # Set the base image
 FROM ubuntu:24.04
@@ -11,16 +13,53 @@ ARG LAUNCHPAD_BUILD_ARCH
 LABEL org.opencontainers.image.ref.name=ubuntu
 LABEL org.opencontainers.image.version=24.04
 
+# Set environment variables for non-interactive installation
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN dpkg --configure -a
 RUN apt update
 RUN apt upgrade -y --autoremove
 RUN apt-get install -y sudo --option=Dpkg::Options::=--force-confdef
 
+# Install wget, gnupg, and software-properties-common for LLVM installation
+RUN apt install -y --no-install-recommends wget gnupg software-properties-common
+
+# Download and install Clang-20 (latest stable) using the official LLVM script
+RUN wget https://apt.llvm.org/llvm.sh
+RUN chmod +x llvm.sh
+RUN yes | ./llvm.sh 20
+
+# Set up update-alternatives for Clang-20 to make it the default
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 100 \
+    --slave /usr/bin/clang++ clang++ /usr/bin/clang++-20 \
+    --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-20 \
+    --slave /usr/bin/clang-cpp clang-cpp /usr/bin/clang-cpp-20 \
+    --slave /usr/bin/clang-cl clang-cl /usr/bin/clang-cl-20 \
+    --slave /usr/bin/clangd clangd /usr/bin/clangd-20 \
+    --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-20 \
+    --slave /usr/bin/clang-check clang-check /usr/bin/clang-check-20 \
+    --slave /usr/bin/clang-query clang-query /usr/bin/clang-query-20 \
+    --slave /usr/bin/asan_symbolize asan_symbolize /usr/bin/asan_symbolize-20 \
+    --slave /usr/bin/bugpoint bugpoint /usr/bin/bugpoint-20 \
+    --slave /usr/bin/dsymutil dsymutil /usr/bin/dsymutil-20 \
+    --slave /usr/bin/lld lld /usr/bin/lld-20 \
+    --slave /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-20 \
+    --slave /usr/bin/lld-link lld-link /usr/bin/lld-link-20 \
+    --slave /usr/bin/llc llc /usr/bin/llc-20 \
+    --slave /usr/bin/lli lli /usr/bin/lli-20 \
+    --slave /usr/bin/obj2yaml obj2yaml /usr/bin/obj2yaml-20 \
+    --slave /usr/bin/opt opt /usr/bin/opt-20 \
+    --slave /usr/bin/sanstats sanstats /usr/bin/sanstats-20 \
+    --slave /usr/bin/verify-uselistorder verify-uselistorder /usr/bin/verify-uselistorder-20 \
+    --slave /usr/bin/wasm-ld wasm-ld /usr/bin/wasm-ld-20 \
+    --slave /usr/bin/yaml2obj yaml2obj /usr/bin/yaml2obj-20
+
+# Install other dependencies
 RUN apt install -y --no-install-recommends python3 python3-pip python3-dev python3-psutil git gcc gdb make findutils bzip2 e2fsprogs
 RUN apt install python3-git python3-yaml python3-schema -y
 
-# clean up apt installs
-RUN apt clean && rm -rf /var/lib/apt/lists/*
+# clean up apt installs and remove the script
+RUN apt clean && rm -rf /var/lib/apt/lists/* && rm llvm.sh
 
 # prepare for artemis runner
 RUN useradd -m --uid 5000 artemis_user


### PR DESCRIPTION
Beyond kernel 6.8, sanitizers tend to have issues.
Therefore, we have to do the following updates:
- update to use gcc13 as previous versions had issues with libasan: see [here](https://stackoverflow.com/questions/78136716/addresssanitizerdeadlysignal-from-fsanitize-address-flag)
- update to use latest stable clang (20.1.7) for best thread sanitizer support after the entropy update: see [here](https://stackoverflow.com/questions/77850769/fatal-threadsanitizer-unexpected-memory-mapping-when-running-on-linux-kernels)

@Sabanic-P can you also publish the respective image in the registry?